### PR TITLE
Provide context for event handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ loginEvent, _ :=  redisevents.New[loginPayload](ctx, goRedisClient, "channelName
 ### 3. Register Handlers
 
 ```go
-func loginHandler1(loginPayload) {
+loginHandler1 := eventbus.NewHandler(func(payload LoginPayload, ctx context.Context) {
     // Handle login event
-}
+})
 
 // The ID is used if we want to UnregisterHandler the handler
 loginEvent.RegisterHandler("someID", loginHandler1)

--- a/event.go
+++ b/event.go
@@ -80,3 +80,15 @@ func (e *event[Payload]) Publish(ctx context.Context, payload Payload) error {
 	defer e.mu.RUnlock()
 	return e.store.Publish(ctx, payload)
 }
+
+type handler[Payload any] struct {
+	handle func(Payload, context.Context)
+}
+
+func (h handler[Payload]) Handle(payload Payload, ctx context.Context) {
+	h.handle(payload, ctx)
+}
+
+func NewHandler[Payload any](fn func(Payload, context.Context)) handler[Payload] {
+	return handler[Payload]{handle: fn}
+}

--- a/event.go
+++ b/event.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 )
 
-var ErrDuplicateID = errors.New("Duplicate handler ID")
+var ErrDuplicateID = errors.New("duplicate handler id")
 
 type Event[Payload any] interface {
 	RegisterHandler(id string, f EventHandler[Payload]) error
@@ -15,7 +15,7 @@ type Event[Payload any] interface {
 }
 
 type EventHandler[Payload any] interface {
-	Handle(payload Payload)
+	Handle(payload Payload, ctx context.Context)
 }
 
 type EventHandlerFunc[Payload any] func(payload Payload)
@@ -43,9 +43,9 @@ type event[Payload any] struct {
 	mu       sync.RWMutex
 }
 
-func (e *event[Payload]) subscribe(payload Payload) {
+func (e *event[Payload]) subscribe(payload Payload, ctx context.Context) {
 	for _, handler := range e.handlers {
-		go handler.Handle(payload)
+		go handler.Handle(payload, ctx)
 	}
 }
 

--- a/memory/memory.go
+++ b/memory/memory.go
@@ -10,7 +10,7 @@ import (
 
 func newStore[Payload any]() *memoryStore[Payload] {
 	return &memoryStore[Payload]{
-		callbacks: make(map[[16]byte]func(Payload)),
+		callbacks: make(map[[16]byte]func(Payload, context.Context)),
 	}
 }
 
@@ -21,7 +21,7 @@ func New[Payload any](ctx context.Context) (eventbus.Event[Payload], error) {
 
 type memoryStore[Payload any] struct {
 	mu        sync.RWMutex
-	callbacks map[[16]byte]func(Payload)
+	callbacks map[[16]byte]func(Payload, context.Context)
 }
 
 func (m *memoryStore[Payload]) Publish(ctx context.Context, payload Payload) error {
@@ -29,13 +29,13 @@ func (m *memoryStore[Payload]) Publish(ctx context.Context, payload Payload) err
 	defer m.mu.Unlock()
 
 	for _, c := range m.callbacks {
-		go c(payload)
+		go c(payload, ctx)
 	}
 
 	return nil
 }
 
-func (m *memoryStore[Payload]) Subscribe(ctx context.Context, f func(Payload)) error {
+func (m *memoryStore[Payload]) Subscribe(ctx context.Context, f func(Payload, context.Context)) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -39,7 +39,7 @@ func (r *redisStore[Payload]) Publish(ctx context.Context, payload Payload) erro
 	return r.client.Publish(ctx, r.channel, buf.String()).Err()
 }
 
-func (r *redisStore[Payload]) Subscribe(ctx context.Context, f func(Payload)) error {
+func (r *redisStore[Payload]) Subscribe(ctx context.Context, f func(Payload, context.Context)) error {
 	sub := r.client.Subscribe(ctx, r.channel)
 
 	go func() {
@@ -52,7 +52,7 @@ func (r *redisStore[Payload]) Subscribe(ctx context.Context, f func(Payload)) er
 				if err != nil {
 					fmt.Printf("ERROR: %v", err)
 				}
-				f(payload)
+				f(payload, ctx)
 				log.Printf("sending to channel %#v", payload)
 			case <-ctx.Done():
 				// close and cleanup the channels

--- a/store.go
+++ b/store.go
@@ -8,5 +8,5 @@ type Store[Payload any] interface {
 	Publish(ctx context.Context, payload Payload) error
 
 	// Free any resources when the context is done
-	Subscribe(ctx context.Context, f func(Payload)) error
+	Subscribe(ctx context.Context, f func(Payload, context.Context)) error
 }


### PR DESCRIPTION
This PR passes the context to the event handler functions. This is relevant information that the handler should have and could potentially read from.

Example

```
type listener[T SomePayload] struct{}

func (l listener[T]) Handle(payload SomePayload, ctx context.Context) {
	fmt.Println("Hello")
}

func main() {
	var handler listener[SomePayload]
	myEvent.RegisterHandler("event_id", handler)
}
```

Also adds a function to create event handler functions called `NewHandler`. README has been updated accordingly, which demonstrates the use of this function.